### PR TITLE
Set nml with vectors

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,12 +1,14 @@
 Package: glmtools
 Type: Package
 Title: glmtools
-Version: 0.14.8
+Version: 0.15.0
 Date: 2017-01-31
 Authors@R: c( person("Jordan", "Read", role = c("aut","cre"),
     email = "jread@usgs.gov"),
     person("Luke", "Winslow", role = "aut",
-    email = "lwinslow@usgs.gov"))
+    email = "lwinslow@usgs.gov"), 
+    person("Joseph", "Stachelek", role = "ctb", 
+    email = "stachel2@msu.edu"))
 Description: Tools for working with the GLM lake model.
 URL: https://github.com/USGS-R/glmtools
 BugReports: https://github.com/USGS-R/glmtools/issues
@@ -35,4 +37,4 @@ VignetteBuilder: knitr
 BuildVignettes: true
 LazyLoad: yes
 LazyData: yes
-RoxygenNote: 6.0.1
+RoxygenNote: 6.1.1

--- a/R/set_nml.R
+++ b/R/set_nml.R
@@ -17,7 +17,7 @@
 #'print(glm_nml)
 #'@seealso \link{get_nml_value}, \link{read_nml}
 #'@export
-set_nml  <-	function(glm_nml,arg_name,arg_val,arg_list=NULL){
+set_nml <- function(glm_nml, arg_name, arg_val, arg_list = NULL){
   
   if (missing(arg_name) & missing(arg_val)){
     return(setnmlList(glm_nml,arg_list))
@@ -46,6 +46,9 @@ set_nml  <-	function(glm_nml,arg_name,arg_val,arg_list=NULL){
   # get appropriate block to place val within ** assumes no duplicate param names in other blocks **
   blck	<-	get_block(glm_nml,arg_name)
   arg_name <- get_arg_name(arg_name)
+  if(length(arg_val) > 1){
+    arg_val <- paste0(arg_val, collapse = ",")
+  }
   glm_nml[[blck]][[arg_name]]	<- arg_val
   return(glm_nml)
 }

--- a/R/set_nml.R
+++ b/R/set_nml.R
@@ -46,7 +46,7 @@ set_nml <- function(glm_nml, arg_name, arg_val, arg_list = NULL){
   # get appropriate block to place val within ** assumes no duplicate param names in other blocks **
   blck	<-	get_block(glm_nml,arg_name)
   arg_name <- get_arg_name(arg_name)
-  if(length(arg_val) > 1){
+  if(length(arg_val) > 1 & is.character(arg_val)){
     arg_val <- paste0(arg_val, collapse = ",")
   }
   glm_nml[[blck]][[arg_name]]	<- arg_val

--- a/tests/testthat/test-nml.R
+++ b/tests/testthat/test-nml.R
@@ -37,6 +37,14 @@ test_that("can read and write nml with vectors", {
     length(get_nml_value(glm_nml, arg_name = "inflow_fl")), 
     1)
   
+  # writing character vectors is backwards compatible
+  glm_nml <- read_nml()
+  glm_nml <- set_nml(glm_nml, arg_name = "inflow_fl", 
+                     arg_val = c("yahara.csv", "yahara2.csv"))
+  expect_equal(
+    length(get_nml_value(glm_nml, arg_name = "inflow_fl")), 
+    1)
+  
   # read numeric vectors
   glm_nml <- read_nml()
   glm_nml <- set_nml(glm_nml, arg_list = list(

--- a/tests/testthat/test-nml.R
+++ b/tests/testthat/test-nml.R
@@ -28,8 +28,8 @@ test_that("can read in nml with vector for logicals", {
   expect_is(get_nml_value(nml, 'flt_off_sw'), 'logical')
 })
 
-test_that("can read and write nml with vectors for character fields", {
-  # read vectors
+test_that("can read and write nml with vectors", {
+  # read character vectors
   glm_nml <- read_nml()
   glm_nml <- set_nml(glm_nml, arg_list = list(
     'inflow_fl' = c("yahara.csv", "yahara2.csv")))
@@ -37,12 +37,25 @@ test_that("can read and write nml with vectors for character fields", {
     length(get_nml_value(glm_nml, arg_name = "inflow_fl")), 
     1)
   
-  # write vectors
+  # read numeric vectors
+  glm_nml <- read_nml()
+  glm_nml <- set_nml(glm_nml, arg_list = list(
+    'A' = c(1, 2, 3)))
+  expect_true(
+    length(get_nml_value(glm_nml, arg_name = "A") > 1))
+  
+  # write character vectors
   write_path <- paste0(tempdir(), 'glm2.nml')
   write_nml(glm_nml, file = write_path)
   expect_equal(
     length(get_nml_value(read_nml(write_path), arg_name = "inflow_fl")), 
     1)
+  
+  # write numeric vectors
+  write_path <- paste0(tempdir(), 'glm2.nml')
+  write_nml(glm_nml, file = write_path)
+  expect_true(
+    length(get_nml_value(read_nml(write_path), arg_name = "A")) > 1)
 })
 
 test_that("can read values from an nml file", {

--- a/tests/testthat/test-nml.R
+++ b/tests/testthat/test-nml.R
@@ -42,7 +42,7 @@ test_that("can read and write nml with vectors", {
   glm_nml <- set_nml(glm_nml, arg_list = list(
     'A' = c(1, 2, 3)))
   expect_true(
-    length(get_nml_value(glm_nml, arg_name = "A") > 1))
+    length(get_nml_value(glm_nml, arg_name = "A")) > 1)
   
   # write character vectors
   write_path <- paste0(tempdir(), 'glm2.nml')

--- a/tests/testthat/test-nml.R
+++ b/tests/testthat/test-nml.R
@@ -28,6 +28,23 @@ test_that("can read in nml with vector for logicals", {
   expect_is(get_nml_value(nml, 'flt_off_sw'), 'logical')
 })
 
+test_that("can read and write nml with vectors for character fields", {
+  # read vectors
+  glm_nml <- read_nml()
+  glm_nml <- set_nml(glm_nml, arg_list = list(
+    'inflow_fl' = c("yahara.csv", "yahara2.csv")))
+  expect_equal(
+    length(get_nml_value(glm_nml, arg_name = "inflow_fl")), 
+    1)
+  
+  # write vectors
+  write_path <- paste0(tempdir(), 'glm2.nml')
+  write_nml(glm_nml, file = write_path)
+  expect_equal(
+    length(get_nml_value(read_nml(write_path), arg_name = "inflow_fl")), 
+    1)
+})
+
 test_that("can read values from an nml file", {
   nml <- read_nml()
   nml <- set_nml(nml, "sim_name", "test")


### PR DESCRIPTION
It looks like nml character fields with more than one value (i.e. vectors) are expected to be written ("collapsed") as a single comma separated string. However, `set_nml` writes them as a vector of strings. 

See MWE at: https://gist.github.com/jsta/2c82af2399bce2ead477727b3e1e2532 

This PR enforces collapsing for character fields passed to `set_nml`.