### PR TITLE
no screen output: plot_compare_stage

### DIFF
--- a/R/plot_compare_stage.R
+++ b/R/plot_compare_stage.R
@@ -41,4 +41,6 @@ plot_compare_stage = function(nc_file, field_file, fig_path = NULL, ...){
 	if (!is.null(fig_path)){
 	  ggsave(plot = h3, filename = fig_path,...)
 	} 
+	
+	return(h3)
 }


### PR DESCRIPTION
Dale and Luke Loken found this while looking at the function, which currently doesn't put out anything to the screen when having fig_path = NULL. The return argument was missing