### PR TITLE
two minor fixes in the calib

### DIFF
--- a/R/calib_helpers.R
+++ b/R/calib_helpers.R
@@ -122,7 +122,7 @@ glmFUN <- function(p, glmcmd, nml_file, var, scaling, metric, verbose){
   
   error <- try(run_glmcmd(glmcmd, path, verbose))
   while (error != 0){
-    error >- try(run_glmcmd(glmcmd, path, verbose))
+    error <- try(run_glmcmd(glmcmd, path, verbose))
   }
   
   mod <- mod2obs(mod_nc = paste0(path,'/output/output.nc'), obs = obs, reference = 'surface',var = var)

--- a/R/calibrate_sim.R
+++ b/R/calibrate_sim.R
@@ -146,7 +146,7 @@ calibrate_sim <- function(var = 'temp',
   nml <- set_nml(nml, arg_list = period$validation)
   write_nml(nml,nml_file)
   
-  run_glm(sim_folder = path, verbose = verbose)
+  run_glmcmd(glmcmd, path, verbose)
   temp_rmse2 <- compare_to_field(output, field_file = field_file, 
                                  metric = 'water.temperature', as_value = FALSE, precision= 'hours')
 
@@ -165,7 +165,7 @@ calibrate_sim <- function(var = 'temp',
   nml <- set_nml(nml, arg_list =total.list)
   write_nml(nml,nml_file)
   
-  run_glm(sim_folder = path, verbose = verbose)
+  run_glmcmd(glmcmd, path, verbose)
   temp_rmse3 <- compare_to_field(output, field_file = field_file, 
                                  metric = 'water.temperature', as_value = FALSE, precision= 'hours')
 


### PR DESCRIPTION
calib_helpers had a wrong declaration sign, 
and calibrate_sim now allows the user to put in an individual GLM call for the validation and total time period evaluation