### PR TITLE
fixed data.frame structure that is returned to user

### DIFF
--- a/R/calibrate_sim.R
+++ b/R/calibrate_sim.R
@@ -71,7 +71,7 @@ calibrate_sim <- function(var = 'temp',
                           output){
   
   # Development message 
-  message('Calibration functions are under development, and are likeley to change with future package updates.')
+  message('Calibration functions are under development, and are likely to change with future package updates.')
   
   if (first.attempt){
     if (file.exists(paste0(path,'/calib_results_',metric,'_',var,'.csv'))){

--- a/R/calibrate_sim.R
+++ b/R/calibrate_sim.R
@@ -71,7 +71,7 @@ calibrate_sim <- function(var = 'temp',
                           output){
   
   # Development message 
-  message('Calibration functions are under development, and are likley to change with future package updates.')
+  message('Calibration functions are under development, and are likeley to change with future package updates.')
   
   if (first.attempt){
     if (file.exists(paste0(path,'/calib_results_',metric,'_',var,'.csv'))){
@@ -178,13 +178,7 @@ calibrate_sim <- function(var = 'temp',
   
   
   # print a matrix of our constrained variable space, the initial value and the calibrated value
-  calibrated_results <- cbind(calib_setup, 'calibrated' =round(c(results$wind_factor[1], 
-                                                                 results$wind_factor[1],
-                                                                 results$ch[1],
-                                                                 results$sed_temp_mean[1],
-                                                                 results$sed_temp_mean.1[1],
-                                                                 results$coef_mix_hyp[1],
-                                                                 results$Kw[1]),4))
+  calibrated_results <- cbind(calib_setup, 'calibrated' = as.numeric(round(results[1,2:(ncol(results)-1)],4)))
   
   print(paste('calibration:',round(temp_rmse1,2),'deg C RMSE'))
   print(paste('validation:',round(temp_rmse2,2),'deg C RMSE'))


### PR DESCRIPTION
when running calibrate_sim.R the output was a hard coded data frame, which produced an error when the user gave different variables as input. This was fixed now.